### PR TITLE
feature: support throttle retain

### DIFF
--- a/conf/ds/fluent-bit.conf
+++ b/conf/ds/fluent-bit.conf
@@ -29,6 +29,15 @@
     multiline.parser     docker, cri
 
 [FILTER]
+    Name         throttle
+    Match        *
+    Rate         ${FLUENTBIT_THROTTLE_RATE}
+    Window       5
+    Interval     1s
+    Print_Status ${FLUENTBIT_THROTTLE_PRINT_STATUS}
+    Retain       ${FLUENTBIT_THROTTLE_RETAIN}
+
+[FILTER]
     name            parser
     Match           *
     Key_Name        log

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -30,6 +30,7 @@ RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ buster-backports main 
 RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list
 RUN true
 
+COPY filter_throttle_patch /tmp/filter_throttle_patch
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
@@ -51,7 +52,8 @@ RUN apt-get update && \
     && cd tmp/ && mkdir fluent-bit \
     && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
     && cd fluent-bit/build/ \
-    && rm -rf /tmp/fluent-bit/build/*
+    && rm -rf /tmp/fluent-bit/build/* \
+    && if [ "$FLB_VERSION" = "1.8.11" ] ; then rm -rf /tmp/fluent-bit/plugins/filter_throttle/throttle.c;  rm -rf /tmp/fluent-bit/plugins/filter_throttle/throttle.h; cp /tmp/filter_throttle_patch/* /tmp/fluent-bit/plugins/filter_throttle/; fi
 
 WORKDIR /tmp/fluent-bit/build/
 RUN cmake -DFLB_RELEASE=On \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,16 @@ if [ -z ${MASTER_VIP_URL} ]; then
     export MASTER_VIP_URL='https://kubernetes.default.svc:443'
 fi
 
+if [ -z ${FLUENTBIT_THROTTLE_RATE} ]; then
+    export FLUENTBIT_THROTTLE_RATE=10000
+fi
+if [ -z ${FLUENTBIT_THROTTLE_RETAIN} ]; then
+    export FLUENTBIT_THROTTLE_RETAIN=true
+fi
+if [ -z ${FLUENTBIT_THROTTLE_PRINT_STATUS} ]; then
+    export FLUENTBIT_THROTTLE_PRINT_STATUS=false
+fi
+
 if [ -z ${CONFIG_FILE} ]; then
     export CONFIG_FILE=/fluent-bit/etc/ds/fluent-bit.conf
 fi

--- a/filter_throttle_patch/throttle.c
+++ b/filter_throttle_patch/throttle.c
@@ -1,0 +1,316 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_filter_plugin.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_time.h>
+#include <msgpack.h>
+#include "stdlib.h"
+
+#include "throttle.h"
+#include "window.h"
+
+#include <stdio.h>
+#include <sys/types.h>
+
+
+static bool apply_suffix (double *x, char suffix_char)
+{
+  int multiplier;
+
+  switch (suffix_char)
+    {
+    case 0:
+    case 's':
+      multiplier = 1;
+      break;
+    case 'm':
+      multiplier = 60;
+      break;
+    case 'h':
+      multiplier = 60 * 60;
+      break;
+    case 'd':
+      multiplier = 60 * 60 * 24;
+      break;
+    default:
+      return false;
+    }
+
+  *x *= multiplier;
+
+  return true;
+}
+
+
+void *time_ticker(void *args)
+{
+    struct ticker *t = args;
+    struct flb_time ftm;
+    long timestamp;
+    struct flb_filter_throttle_ctx *ctx = t->ctx;
+
+    while (!t->done) {
+        flb_time_get(&ftm);
+        timestamp = flb_time_to_double(&ftm);
+        window_add(t->ctx->hash, timestamp, 0);
+
+        t->ctx->hash->current_timestamp = timestamp;
+
+        if (t->ctx->print_status) {
+            flb_plg_info(ctx->ins,
+                         "%ld: limit is %0.2f per %s with window size of %i, retain is %i,"
+                         "current rate is: %i per interval",
+                         timestamp, t->ctx->max_rate, t->ctx->slide_interval,
+                         t->ctx->window_size, t->ctx->retain,
+                         t->ctx->hash->total / t->ctx->hash->size);
+        }
+        sleep(t->seconds);
+    }
+
+    return NULL;
+}
+
+/* Given a msgpack record, do some filter action based on the defined rules */
+static inline int throttle_data(struct flb_filter_throttle_ctx *ctx)
+{
+    if ((ctx->hash->total / (double) ctx->hash->size) >= ctx->max_rate) {
+        return THROTTLE_RET_DROP;
+    }
+
+    window_add(ctx->hash, ctx->hash->current_timestamp, 1);
+
+    return THROTTLE_RET_KEEP;
+}
+
+static inline bool get_retain(struct flb_filter_throttle_ctx *ctx)
+{
+    if (ctx->retain) {
+        return true;
+    }
+    return false;
+}
+
+static int configure(struct flb_filter_throttle_ctx *ctx, struct flb_filter_instance *f_ins)
+{
+    const char *str = NULL;
+    double val  = 0;
+    char *endp;
+
+    /* rate per second */
+    str = flb_filter_get_property("rate", f_ins);
+
+    if (str != NULL && (val = strtod(str, &endp)) > 1) {
+        ctx->max_rate = val;
+    } else {
+        ctx->max_rate = THROTTLE_DEFAULT_RATE;
+    }
+
+    /* windows size */
+    str = flb_filter_get_property("window", f_ins);
+    if (str != NULL && (val = strtoul(str, &endp, 10)) > 1) {
+        ctx->window_size = val;
+    } else {
+        ctx->window_size = THROTTLE_DEFAULT_WINDOW;
+    }
+
+    /* print informational status */
+    str = flb_filter_get_property("print_status", f_ins);
+    if (str != NULL) {
+        ctx->print_status = flb_utils_bool(str);
+    } else {
+        ctx->print_status = THROTTLE_DEFAULT_STATUS;
+    }
+
+    /* sliding interval */
+    str = flb_filter_get_property("interval", f_ins);
+    if (str != NULL) {
+        ctx->slide_interval = str;
+    } else {
+        ctx->slide_interval = THROTTLE_DEFAULT_INTERVAL;
+    }
+
+    /* retain */
+    str = flb_filter_get_property("retain", f_ins);
+    if (str != NULL) {
+        ctx->retain = flb_utils_bool(str);
+    } else {
+        ctx->retain = THROTTLE_DEFAULT_RETAIN;
+    }
+
+    return 0;
+}
+
+static int parse_duration(struct flb_filter_throttle_ctx *ctx,
+                          const char *interval)
+{
+    double seconds = 0.0;
+    double s;
+    char *p;
+
+    s = strtod(interval, &p);
+    if  ( 0 >= s
+          /* No extra chars after the number and an optional s,m,h,d char.  */
+          || (*p && *(p+1))
+          /* Check any suffix char and update S based on the suffix.  */
+          || ! apply_suffix (&s, *p))
+        {
+            flb_plg_warn(ctx->ins,
+                         "invalid time interval %s falling back to default: 1 "
+                         "second",
+                         interval);
+        }
+
+      seconds += s;
+      return seconds;
+}
+
+static int cb_throttle_init(struct flb_filter_instance *f_ins,
+                        struct flb_config *config,
+                        void *data)
+{
+    int ret;
+    pthread_t tid;
+    struct ticker *ticker_ctx;
+    struct flb_filter_throttle_ctx *ctx;
+
+    /* Create context */
+    ctx = flb_malloc(sizeof(struct flb_filter_throttle_ctx));
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+    ctx->ins = f_ins;
+
+    /* parse plugin configuration  */
+    ret = configure(ctx, f_ins);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
+    ticker_ctx = flb_malloc(sizeof(struct ticker));
+    if (!ticker_ctx) {
+        flb_errno();
+        flb_free(ctx);
+        return -1;
+    }
+
+    /* Set our context */
+    flb_filter_set_context(f_ins, ctx);
+
+    ctx->hash = window_create(ctx->window_size);
+
+    ticker_ctx->ctx = ctx;
+    ticker_ctx->done = false;
+    ticker_ctx->seconds = parse_duration(ctx, ctx->slide_interval);
+    pthread_create(&tid, NULL, &time_ticker, ticker_ctx);
+    return 0;
+}
+
+static int cb_throttle_filter(const void *data, size_t bytes,
+                              const char *tag, int tag_len,
+                              void **out_buf, size_t *out_size,
+                              struct flb_filter_instance *f_ins,
+                              void *context,
+                              struct flb_config *config)
+{
+    int ret;
+    bool retain = false;
+    int old_size = 0;
+    int new_size = 0;
+    msgpack_unpacked result;
+    msgpack_object root;
+    size_t off = 0;
+    (void) f_ins;
+    (void) config;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+
+    /* Create temporary msgpack buffer */
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+
+
+    /* Iterate each item array and apply rules */
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, data, bytes, &off) == MSGPACK_UNPACK_SUCCESS) {
+        root = result.data;
+        if (root.type != MSGPACK_OBJECT_ARRAY) {
+            continue;
+        }
+
+        old_size++;
+
+        ret = throttle_data(context);
+        retain = get_retain(context);
+        if (ret == THROTTLE_RET_KEEP) {
+            msgpack_pack_object(&tmp_pck, root);
+            new_size++;
+        }
+        else if (ret == THROTTLE_RET_DROP) {
+            /* If Retain is false, Do nothing */
+            if (retain) {
+                usleep(10 * 1000);
+                msgpack_pack_object(&tmp_pck, root);
+                new_size++;
+             }
+        }
+    }
+    msgpack_unpacked_destroy(&result);
+
+    /* we keep everything ? */
+    if (old_size == new_size) {
+        /* Destroy the buffer to avoid more overhead */
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return FLB_FILTER_NOTOUCH;
+    }
+
+    /* link new buffers */
+    *out_buf   = tmp_sbuf.data;
+    *out_size = tmp_sbuf.size;
+
+    return FLB_FILTER_MODIFIED;
+}
+
+static int cb_throttle_exit(void *data, struct flb_config *config)
+{
+    struct flb_filter_throttle_ctx *ctx = data;
+
+    flb_free(ctx->hash->table);
+    flb_free(ctx->hash);
+    flb_free(ctx);
+    return 0;
+}
+
+struct flb_filter_plugin filter_throttle_plugin = {
+    .name         = "throttle",
+    .description  = "Throttle messages using sliding window algorithm",
+    .cb_init      = cb_throttle_init,
+    .cb_filter    = cb_throttle_filter,
+    .cb_exit      = cb_throttle_exit,
+    .flags        = 0
+};

--- a/filter_throttle_patch/throttle.h
+++ b/filter_throttle_patch/throttle.h
@@ -1,0 +1,56 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit Throttling
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_FILTER_THROTTLE_H
+#define FLB_FILTER_THROTTLE_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_filter.h>
+
+/* actions */
+#define THROTTLE_RET_KEEP  0
+#define THROTTLE_RET_DROP  1
+
+/* defaults */
+#define THROTTLE_DEFAULT_RATE  1
+#define THROTTLE_DEFAULT_WINDOW  5
+#define THROTTLE_DEFAULT_INTERVAL  "1"
+#define THROTTLE_DEFAULT_STATUS FLB_FALSE;
+#define THROTTLE_DEFAULT_RETAIN FLB_FALSE;
+
+struct flb_filter_throttle_ctx {
+    double    max_rate;
+    unsigned int    window_size;
+    const char  *slide_interval;
+    int print_status;
+    int retain;
+
+    /* internal */
+    struct throttle_window *hash;
+    struct flb_filter_instance *ins;
+};
+
+struct ticker {
+    struct flb_filter_throttle_ctx *ctx;
+    bool done;
+    double seconds;
+};
+
+#endif


### PR DESCRIPTION
以补丁的方式替换 fluent-bit 1.8.11 版本的 Filter 插件 throttle 的 throttle.c 和 throttle.h 文件，编译构建的 fluent-bit 镜像的 throttle 插件支持采端集节点级限流，同时在日志流量超出限制的时候不丢失