### PR TITLE
ensure_time: use UTC directly, drop regex for timezone to speedup; add benchmark

### DIFF
--- a/conf/ds/time.lua
+++ b/conf/ds/time.lua
@@ -10,19 +10,16 @@ function ensure_time(_, timestamp, record)
     local sec = math.floor(timestamp)
     local nsec = math.floor((timestamp - sec) * 1e9)
 
-    -- 将时间戳转换为指定格式的日期字符串
-    local zone = os.date("%z", timestamp)
-    zone = tostring(zone)
-    if string.len(zone) > 0 then
-        -- add `:` to zone, change +0800 to +08:00
-        zone = tostring(zone):gsub("^(%+)(%d%d)(%d%d)$", "%1%2:%3")
-    else
-        zone = "Z"
-    end
+    -- 将时间戳转换为指定格式的日期字符串, zone=UTC
+    local dateStr = os.date("!%Y-%m-%dT%H:%M:%S", sec) .. string.format(".%09d", nsec) .. "Z"
 
-    -- 生成日期字符串
-    local dateStr = os.date("%Y-%m-%dT%H:%M:%S", sec) .. string.format(".%09d", nsec) .. zone
     record[timeField] = dateStr
 
     return 2, timestamp, record
 end
+
+-- -- invoke ensure_time for benchmark
+-- local socket = require("socket")
+-- local record = { time = "2021-01-01T00:00:00Z" }
+-- local _, _, record = ensure_time(nil, socket.gettime(), record)
+-- print(record["time"])

--- a/conf/ds/time_bench_test.go
+++ b/conf/ds/time_bench_test.go
@@ -1,0 +1,27 @@
+package ds_test
+
+import (
+	"embed"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+//go:embed time.lua
+var timeLua embed.FS
+
+func Benchmark_lua_ensure_time(b *testing.B) {
+	f, _ := os.CreateTemp("/tmp", "")
+	bytes, _ := timeLua.ReadFile("time.lua")
+	f.Write(bytes)
+	// write from embed.FS to file
+	for i := 0; i < b.N; i++ {
+		cmd := exec.Command("lua", f.Name())
+		//cmd.Stdout = os.Stdout
+		//cmd.Stderr = os.Stdout
+		err := cmd.Run()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
ensure_time:
- use UTC directly, drop regex for timezone to speedup
- add benchmark, see time cost per op
<img width="1164" alt="image" src="https://github.com/erda-project/erda-fluent-bit/assets/13919034/8f4912c2-b23d-4c45-819a-58b78971cca4">

